### PR TITLE
Lock only major versions of Angular dependencies

### DIFF
--- a/saturn-datepicker/package.json
+++ b/saturn-datepicker/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "private": false,
   "peerDependencies": {
-    "@angular/common": "8.2.6",
-    "@angular/compiler": "8.2.6",
+    "@angular/common": "^8.2.0",
+    "@angular/compiler": "^8.2.0",
     "@angular/material": "^8.2.0",
     "@angular/cdk": "^8.2.0"
   },


### PR DESCRIPTION
To get rid of warnings