### PR TITLE
Add rangeHoverEffect parameter to sat-datepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,5 +141,21 @@ By default the option is false
    </mat-form-field>
 ```
 
+### In range mode, how to disable the mouseover effect ?
+`rangeHoverEffect` option enables or disables the mouseover listener on days when the rangeMode parameter is used and is enabled.
+By default the option is true
+
+```angular2html
+  <mat-form-field>
+    <input matInput [satDatepicker]="resultPicker">
+    <sat-datepicker
+        #resultPicker
+        [rangeMode]="true"
+        [closeAfterSelection]="false"
+        [rangeHoverEffect]="false">
+    </sat-datepicker>
+   </mat-form-field>
+```
+
 ---
 Licence: MIT

--- a/saturn-datepicker/README.md
+++ b/saturn-datepicker/README.md
@@ -139,5 +139,21 @@ By default the option is false
    </mat-form-field>
 ```
 
+### In range mode, how to disable the mouseover effect ?
+`rangeHoverEffect` option enables or disables the mouseover listener on days when the rangeMode parameter is used and is enabled.
+By default the option is true
+
+```angular2html
+  <mat-form-field>
+    <input matInput [satDatepicker]="resultPicker">
+    <sat-datepicker
+        #resultPicker
+        [rangeMode]="true"
+        [closeAfterSelection]="false"
+        [rangeHoverEffect]="false">
+    </sat-datepicker>
+   </mat-form-field>
+```
+
 ---
 Licence: MIT

--- a/saturn-datepicker/package-lock.json
+++ b/saturn-datepicker/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "saturn-datepicker",
-  "version": "8.0.1",
-  "lockfileVersion": 1
-}

--- a/saturn-datepicker/package-lock.json
+++ b/saturn-datepicker/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "saturn-datepicker",
+  "version": "8.0.1",
+  "lockfileVersion": 1
+}

--- a/saturn-datepicker/src/datepicker/calendar-body.ts
+++ b/saturn-datepicker/src/datepicker/calendar-body.ts
@@ -133,7 +133,7 @@ export class SatCalendarBody implements OnChanges {
   }
 
   _mouseOverCell(cell: SatCalendarCell): void {
-    if (this.rangeHoverEffect) this._cellOver = cell.value
+    if (this.rangeHoverEffect) this._cellOver = cell.value;
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/saturn-datepicker/src/datepicker/calendar-body.ts
+++ b/saturn-datepicker/src/datepicker/calendar-body.ts
@@ -60,6 +60,9 @@ export class SatCalendarBody implements OnChanges {
   /** The label for the table. (e.g. "Jan 2017"). */
   @Input() label: string;
 
+  /** Enables datepicker MouseOver effect on range mode */
+  @Input() rangeHoverEffect = true;
+
   /** The cells to display in the table. */
   @Input() rows: SatCalendarCell[][];
 
@@ -130,7 +133,7 @@ export class SatCalendarBody implements OnChanges {
   }
 
   _mouseOverCell(cell: SatCalendarCell): void {
-    this._cellOver = cell.value;
+    if (this.rangeHoverEffect) this._cellOver = cell.value
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/saturn-datepicker/src/datepicker/calendar.html
+++ b/saturn-datepicker/src/datepicker/calendar.html
@@ -10,6 +10,7 @@
       [endDate]="endDate"
       [rangeMode]="rangeMode"
       [closeAfterSelection]="closeAfterSelection"
+      [rangeHoverEffect]="rangeHoverEffect"
       [dateFilter]="dateFilter"
       [maxDate]="maxDate"
       [minDate]="minDate"

--- a/saturn-datepicker/src/datepicker/calendar.ts
+++ b/saturn-datepicker/src/datepicker/calendar.ts
@@ -231,6 +231,9 @@ export class SatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
     /** Whenever datepicker is for selecting range of dates. */
     @Input() rangeMode = false;
 
+    /** Enables datepicker MouseOver effect on range mode */
+    @Input() rangeHoverEffect = true;
+
     /** Enables datepicker closing after selection */
     @Input() closeAfterSelection = true;
 

--- a/saturn-datepicker/src/datepicker/datepicker-content.html
+++ b/saturn-datepicker/src/datepicker/datepicker-content.html
@@ -6,6 +6,7 @@
     [minDate]="datepicker._minDate"
     [maxDate]="datepicker._maxDate"
     [dateFilter]="datepicker._dateFilter"
+    [rangeHoverEffect]="datepicker.rangeHoverEffect"
     [headerComponent]="datepicker.calendarHeaderComponent"
     [footerComponent]="datepicker.calendarFooterComponent"
     [selected]="datepicker._selected"

--- a/saturn-datepicker/src/datepicker/datepicker.ts
+++ b/saturn-datepicker/src/datepicker/datepicker.ts
@@ -272,6 +272,9 @@ export class SatDatepicker<D> implements OnDestroy, CanColor {
   /** Enables datepicker closing after selection */
   @Input() closeAfterSelection = true;
 
+  /** Enables datepicker MouseOver effect on range mode */
+  @Input() rangeHoverEffect = true;
+
   /** In range mod, enable datepicker to select the first date selected as a one-day-range,
    * if the user closes the picker before selecting another date
    */

--- a/saturn-datepicker/src/datepicker/month-view.html
+++ b/saturn-datepicker/src/datepicker/month-view.html
@@ -14,6 +14,7 @@
          [isBeforeSelected]="_beginDateSelected && _dateAdapter.compareDate(activeDate, _beginDateSelected) < 0"
          [rangeFull]="_rangeFull"
          [rangeMode]="rangeMode"
+         [rangeHoverEffect]="rangeHoverEffect"
          [labelMinRequiredCells]="3"
          [activeCell]="_dateAdapter.getDate(activeDate) - 1"
          (selectedValueChange)="_dateSelected($event)"

--- a/saturn-datepicker/src/datepicker/month-view.ts
+++ b/saturn-datepicker/src/datepicker/month-view.ts
@@ -76,6 +76,9 @@ export class SatMonthView<D> implements AfterContentInit {
   /** Allow selecting range of dates. */
   @Input() rangeMode = false;
 
+  /** Enables datepicker MouseOver effect on range mode */
+  @Input() rangeHoverEffect = true;
+
   /** Enables datepicker closing after selection */
   @Input() closeAfterSelection = true;
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -126,4 +126,19 @@
       </div>
     </section>
     <hr>
+    <section>
+        <h2>Disable range mouseover effect</h2>
+        <div>
+            <span class="code">rangeHoverEffect</span> option enables or disables the mouseover listener on days when the rangeMode parameter is used and is enabled.
+                By default the option is <span class="code">true</span>
+        </div>
+        <mat-form-field>
+            <input matInput
+                   placeholder="Choose a date"
+                   [satDatepicker]="picker8"
+                   value="">
+            <sat-datepicker [rangeMode]="true" [rangeHoverEffect]="false" [closeAfterSelection]="false" [rangeMode]="true" #picker8></sat-datepicker>
+            <sat-datepicker-toggle matSuffix [for]="picker8"></sat-datepicker-toggle>
+        </mat-form-field>
+    </section>
 </form>


### PR DESCRIPTION
This change is for those users who prefer to not have the mouseover effect when rangeMode is enabled.