### PR TITLE
feat: add reset method to remove selected dates

### DIFF
--- a/saturn-datepicker/src/datepicker/calendar.ts
+++ b/saturn-datepicker/src/datepicker/calendar.ts
@@ -489,4 +489,16 @@ export class SatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
   private _getCurrentViewComponent() {
     return this.monthView || this.yearView || this.multiYearView;
   }
+
+  /** Reset inserted values */
+  public _reset() {
+    if (!this.rangeMode) {
+      this._selected = null;
+      return this.selectedChange.emit(null);
+    }
+    this._beginDate = null;
+    this._endDate = null;
+    this.beginDateSelected = null;
+    this.dateRangesChange.emit(null);
+  }
 }

--- a/saturn-datepicker/src/datepicker/calendar.ts
+++ b/saturn-datepicker/src/datepicker/calendar.ts
@@ -453,6 +453,7 @@ export class SatCalendar<D> implements AfterContentInit, AfterViewChecked, OnDes
           this.dateRangesChange.emit({begin: <D>this.beginDate, end: this.endDate});
         }
     } else if (!this._dateAdapter.sameDate(date, this.selected)) {
+      this.selected = date;
       this.selectedChange.emit(date);
     }
   }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -110,18 +110,42 @@
     </section>
     <hr>
     <section>
-      <h2>Inline Usage</h2>
+      <h2>Inline Usage - Range</h2>
       <div>
           The <span class="code">sat-calendar</span> component with its <span class="code">dateRangesChange</span> output binding can be used as an inline range date picker. Validation NOT WORKING.
       </div>
       <span class="code" *ngIf="inlineRange">
         {{ inlineRange.begin | date }}
         {{ inlineRange.end | date }}
+        <button mat-button (click)="resetRange()">Reset</button>
+      </span>
+      <span class="code" *ngIf="inlineBeginDate && !inlineRange">
+        {{ inlineBeginDate | date }}
+        <button mat-button (click)="resetRange()">Reset</button>
       </span>
       <div class="inlineCalendarContainer">
         <sat-calendar [rangeMode]="true"
                       (dateRangesChange)="inlineRangeChange($event)"
-                      [selected]="selectedDate">
+                      (beginDateSelectedChange)="inlineBeginChange($event)"
+                      #inlineRangePicker>
+        </sat-calendar>
+      </div>
+    </section>
+    <hr>
+    <section>
+      <h2>Inline Usage - Single Date</h2>
+      <div>
+          The <span class="code">sat-calendar</span> component with its <span class="code">selectedChange</span> output binding can be used as an inline date picker. Validation NOT WORKING.
+      </div>
+      <span class="code" *ngIf="selectedDate">
+        {{ selectedDate | date }}
+        <button mat-button (click)="resetSingleDate()">Reset</button>
+      </span>
+      <div class="inlineCalendarContainer">
+        <sat-calendar [rangeMode]="false"
+                      (selectedChange)="inlineSingleDateChange($event)"
+                      [selected]="selectedDate"
+                      #inlineSingleDatePicker>
         </sat-calendar>
       </div>
     </section>
@@ -137,7 +161,7 @@
                    placeholder="Choose a date"
                    [satDatepicker]="picker8"
                    value="">
-            <sat-datepicker [rangeMode]="true" [rangeHoverEffect]="false" [closeAfterSelection]="false" [rangeMode]="true" #picker8></sat-datepicker>
+            <sat-datepicker [rangeMode]="true" [rangeHoverEffect]="false" [closeAfterSelection]="false" #picker8></sat-datepicker>
             <sat-datepicker-toggle matSuffix [for]="picker8"></sat-datepicker-toggle>
         </mat-form-field>
     </section>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { RangesFooter } from './ranges-footer.component';
 
@@ -8,9 +8,13 @@ import { RangesFooter } from './ranges-footer.component';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
+  @ViewChild('inlineRangePicker', {static: false}) inlineRangePicker;
+  @ViewChild('inlineSingleDatePicker', {static: false}) inlineSingleDatePicker;
+
   form: FormGroup;
   rangesFooter = RangesFooter;
   inlineRange;
+  inlineBeginDate;
   selectedDate;
 
   constructor(fb: FormBuilder) {
@@ -21,6 +25,26 @@ export class AppComponent {
 
   inlineRangeChange($event) {
     this.inlineRange = $event;
+  }
+
+  inlineBeginChange($event) {
+    this.inlineBeginDate = $event;
+  }
+
+  inlineSingleDateChange($event) {
+    this.selectedDate = $event;
+  }
+
+  resetRange() {
+    this.inlineRange = undefined;
+    this.inlineBeginDate = undefined;
+
+    this.inlineRangePicker._reset();
+  }
+
+  resetSingleDate() {
+    this.selectedDate = undefined;
+    this.inlineRangePicker._reset();
   }
 
 }


### PR DESCRIPTION
1. feat: add a reset method to the calendar component
2. fix: set selected date when range mode is disabled in calendar
3. chore: add examples for reset calendar in range and single-mode

Related to: https://github.com/SaturnTeam/saturn-datepicker/issues/58