### PR TITLE
remove theme styles duplication

### DIFF
--- a/saturn-datepicker/src/_theming.scss
+++ b/saturn-datepicker/src/_theming.scss
@@ -1,7 +1,7 @@
 @import '~@angular/material/theming';
 
 @mixin sat-datepicker-theme($theme) {
-  @include mat-datepicker-theme($theme);
+  @include _mat-datepicker-color($theme);
   $primary: map-get($theme, primary);
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);


### PR DESCRIPTION

WARNING: The same color styles are generated multiple times. Read more about how style duplication can be avoided in a dedicated guide. https://github.com/angular/components/blob/master/guides/duplicate-theming-styles.md
    node_modules\@angular\material\_theming.scss 1648:7  -mat-check-duplicate-theme-styles()
    node_modules\@angular\material\_theming.scss 3763:3  mat-datepicker-theme()
    node_modules\saturn-datepicker\_theming.scss 4:3     sat-datepicker-theme()
    stdin 6:1                                            root stylesheet