### PR TITLE
Fixed randomly selected date when using rangeHoverEffect=false and ch…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ I created this repository and this package due to it takes a lot of time to cont
 3) **You can use all original material attributes: min, max, formControl and others**
 
 ## Changelog
+## 8.0.6
+Fixed randomly selected date when using `rangeHoverEffect = false` and changing between months
 ## 8.0.5
 Works with angular 9.0
 ## 8.0.4

--- a/saturn-datepicker/README.md
+++ b/saturn-datepicker/README.md
@@ -15,6 +15,8 @@ I created this repository and this package due to it takes a lot of time to cont
 3) **You can use all original material attributes: min, max, formControl and others**
 
 ## Changelog
+## 8.0.6
+Fixed randomly selected date when using `rangeHoverEffect = false` and changing between months
 ## 8.0.5
 Works with angular 9.0
 ## 8.0.4

--- a/saturn-datepicker/package.json
+++ b/saturn-datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saturn-datepicker",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "repository": "https://github.com/SaturnTeam/saturn-datepicker",
   "keywords": ["angular", "material", "datepicker", "range datepicker"],
   "author": "saturn <saturn@saturn.team>",

--- a/saturn-datepicker/src/datepicker/calendar-body.ts
+++ b/saturn-datepicker/src/datepicker/calendar-body.ts
@@ -133,7 +133,9 @@ export class SatCalendarBody implements OnChanges {
   }
 
   _mouseOverCell(cell: SatCalendarCell): void {
-    if (this.rangeHoverEffect) this._cellOver = cell.value;
+    if (this.rangeHoverEffect) {
+      this._cellOver = cell.value;
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -153,7 +155,10 @@ export class SatCalendarBody implements OnChanges {
     }
 
     if (changes.activeCell) {
-      this._cellOver = this.activeCell + 1;
+      // Only modify hovered cell variable when rangeHoverEffect is enabled
+      if (this.rangeHoverEffect) {
+        this._cellOver = this.activeCell + 1;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the following testcase:

- Set `rangeHoverEffect` to `false`
- Pick a beginning date.
- Click next month

Then a randomly end date and range is semiselected. 